### PR TITLE
chore(security): disable dependency install scripts (ignore-scripts)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Security: do not run dependency lifecycle (install/postinstall) scripts.
+# Prevents arbitrary code execution from transitive packages during install
+# (supply-chain hardening). The project itself defines no install/prepare
+# hooks, and `npm run <script>` (lint/test/start) is unaffected.
+ignore-scripts=true


### PR DESCRIPTION
## What

Adds a project-level `.npmrc` with `ignore-scripts=true`, so **transitive dependencies cannot execute `install`/`postinstall` lifecycle scripts** during `npm ci` / `npm install`. This closes a supply-chain arbitrary-code-execution vector.

Previously every install ran postinstall scripts from:
- `protobufjs` (`node scripts/postinstall`)
- `unrs-resolver` (`node postinstall.js`)
- `fsevents` (native build)

## Why this is safe here

- The project defines **no** `install`/`postinstall`/`prepare` hooks of its own.
- Explicitly invoked scripts (`npm run lint` / `test` / `start`) are **not** affected by `ignore-scripts` — only lifecycle hooks during install are.
- CI runs `npm ci` from the repo root, so it picks up `.npmrc` automatically — no workflow change required.

## Verification (with scripts disabled)

- `rm -rf node_modules && npm ci` → clean, no script execution
- `npm run lint` → eslint passes (`unrs-resolver`'s native binding loads from its **prebuilt optional dependency** `@unrs/resolver-binding-*`, which needs no script)
- `npm test` → **281 passed**, 16 skipped
- `npm config get ignore-scripts` → `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)