### PR TITLE
fix(security): resolve CodeQL alerts (CORS + workflow permissions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Least-privilege default token for all jobs (CodeQL: missing-workflow-permissions).
+# Jobs that need more declare their own permissions block.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/src/app.js
+++ b/src/app.js
@@ -22,10 +22,15 @@ app.set('trust proxy', 1);
 // Security middleware
 app.use(helmet());
 
-// CORS middleware
+// CORS middleware — restrict to an explicit allowlist via CORS_ORIGIN
+// (comma-separated origins). Defaults to same-origin only rather than a
+// permissive wildcard (CodeQL: js/cors-permissive-configuration).
+const corsOrigin = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(',').map((origin) => origin.trim())
+  : false;
 app.use(
   cors({
-    origin: process.env.CORS_ORIGIN || '*',
+    origin: corsOrigin,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
   })

--- a/tests/unit/app.test.js
+++ b/tests/unit/app.test.js
@@ -191,6 +191,26 @@ describe('Express App Module', () => {
 
       expect(response.status).not.toBe(405);
     });
+
+    it('reflects an allowed origin when CORS_ORIGIN is configured', async () => {
+      const original = process.env.CORS_ORIGIN;
+      // Comma-separated allowlist (with surrounding spaces to exercise trim()).
+      process.env.CORS_ORIGIN = 'http://allowed.com, http://second.com';
+      jest.resetModules();
+      const configuredApp = require('../../src/app');
+
+      const response = await request(configuredApp)
+        .get('/')
+        .set('Origin', 'http://allowed.com');
+
+      expect(response.headers['access-control-allow-origin']).toBe('http://allowed.com');
+
+      if (original === undefined) {
+        delete process.env.CORS_ORIGIN;
+      } else {
+        process.env.CORS_ORIGIN = original;
+      }
+    });
   });
 
   describe('Request Logging', () => {

--- a/tests/unit/app.test.js
+++ b/tests/unit/app.test.js
@@ -146,10 +146,13 @@ describe('Express App Module', () => {
       expect(response.status).not.toBe(500);
     });
 
-    it('should handle CORS', async () => {
+    it('should not set a permissive CORS origin by default', async () => {
+      // With no CORS_ORIGIN configured the API is same-origin only, so a
+      // cross-origin request gets no Access-Control-Allow-Origin header
+      // (no permissive wildcard).
       const response = await request(app).get('/').set('Origin', 'http://example.com');
 
-      expect(response.headers).toHaveProperty('access-control-allow-origin');
+      expect(response.headers['access-control-allow-origin']).toBeUndefined();
     });
 
     it('should set security headers with helmet', async () => {


### PR DESCRIPTION
Resolves the 4 open CodeQL code-scanning alerts.

### `js/cors-permissive-configuration` — src/app.js
CORS defaulted to a permissive wildcard (`origin: process.env.CORS_ORIGIN || '*'`), reflecting any origin. Now:
```js
const corsOrigin = process.env.CORS_ORIGIN
  ? process.env.CORS_ORIGIN.split(',').map((origin) => origin.trim())
  : false;
```
- Explicit allowlist via `CORS_ORIGIN` (comma-separated).
- **Secure default**: same-origin only (`origin: false`) instead of a wildcard. The app test was updated to assert no `Access-Control-Allow-Origin` header is set when unconfigured.

### `actions/missing-workflow-permissions` ×3 — ci.yml
Added a top-level least-privilege `permissions: contents: read` default (jobs needing more keep their own block).

> The 3 Trivy `high` alerts are base-image OS packages (handled separately from CodeQL); not in scope for this PR.

## Verification
- `npm run lint` clean
- `npm test` → **281 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)